### PR TITLE
OL10 build for 8.4.6 / 9.4.0 (wip)

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -123,7 +123,7 @@
 9.3.0       ol9        centos9__9.1.0.sh    field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.3.0-1.el9.src.rpm
 9.4.0       ol9        ol9__9.4.0.sh        field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el9.src.rpm
 
-9.4.0       ol10       ol10__9.4.0.sh       generic_build.sh  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el10.src.rpm
+9.4.0       ol10       ol10__9.4.0.sh       field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el10.src.rpm
 
 # Rocky Linux
 8.0.37      rocky8     centos8__8.0.36+.sh  field__not__used  https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-8.0.37-1.el8.src.rpm

--- a/build.conf
+++ b/build.conf
@@ -123,6 +123,8 @@
 9.3.0       ol9        centos9__9.1.0.sh    field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.3.0-1.el9.src.rpm
 9.4.0       ol9        ol9__9.4.0.sh        field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el9.src.rpm
 
+9.4.0       ol10       ol10__9.4.0.sh       generic_build.sh  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el10.src.rpm
+
 # Rocky Linux
 8.0.37      rocky8     centos8__8.0.36+.sh  field__not__used  https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-8.0.37-1.el8.src.rpm
 8.0.38      rocky8     centos8__8.0.36+.sh  field__not__used  https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-community-8.0.38-1.el8.src.rpm

--- a/build.conf
+++ b/build.conf
@@ -156,3 +156,5 @@
 9.1.0       rocky9     centos9__9.1.0.sh    field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.1.0-1.el9.src.rpm
 9.3.0       rocky9     centos9__9.1.0.sh    field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.3.0-1.el9.src.rpm
 9.4.0       rocky9     ol9__9.4.0.sh        field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el9.src.rpm
+
+9.4.0       rocky10    ol10__9.4.0.sh       field__not__used  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el10.src.rpm

--- a/config/ossetup/ol10__9.4.0.sh
+++ b/config/ossetup/ol10__9.4.0.sh
@@ -35,15 +35,23 @@ yum config-manager --set-enabled $extra_repo
 
 echo "### installing required rpms"
 yum install -y \
+	annobin-annocheck \
+	annobin-plugin-gcc \
 	bind-utils \
+	binutils  \
 	bison \
 	cmake \
 	cyrus-sasl-devel \
+	dwz \
+	gcc \
+	gcc-c++ \
+	gcc-plugin-annobin \
 	git \
 	krb5-devel \
 	libaio-devel \
 	libcurl-devel \
 	libfido2-devel \
+	libquadmath-devel \
 	libtirpc-devel \
 	libudev-devel \
 	ncurses-devel \
@@ -54,12 +62,6 @@ yum install -y \
 	perl-JSON rpcgen \
 	rpm-build \
 	time \
-	annobin-annocheck \
-	annobin-plugin-gcc \
-	binutils  \
-	dwz \
-	gcc \
-	gcc-c++ \
 	wget \
 	zlib-devel
 

--- a/config/ossetup/ol10__9.4.0.sh
+++ b/config/ossetup/ol10__9.4.0.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+############################################################################
+#                                                                          #
+# OS Setup for OL10 for 9.4.0                                              #
+#                                                                          #
+############################################################################
+
+set -e
+
+cd /data
+
+yum update -y
+yum install -y 'dnf-command(config-manager)'
+
+# OEL10 differences vs CentOS 10 stream
+if rpm -q centos-stream-release 2>&1 >/dev/null; then
+	echo "- found CentOS 10 stream"
+	extra_repo=crb
+elif rpm -q oraclelinux-release 2>&1 >/dev/null; then
+	echo "- found Oracle Linux 10"
+	extra_repo=ol10_codeready_builder
+elif rpm -q almalinux-release 2>&1 >/dev/null; then
+	echo "- found Alma Linux 10"
+	extra_repo=crb
+elif rpm -q rocky-release 2>&1 >/dev/null; then
+	echo "- found Rocky Linux 10"
+	extra_repo=crb
+else
+	echo "- OS not recognised, giving up"
+	exit 1
+fi
+echo "### Enabling extra repo: $extra_repo"
+yum config-manager --set-enabled $extra_repo
+
+echo "### installing required rpms"
+yum install -y \
+	bind-utils \
+	bison \
+	cmake \
+	cyrus-sasl-devel \
+	git \
+	krb5-devel \
+	libaio-devel \
+	libcurl-devel \
+	libfido2-devel \
+	libtirpc-devel \
+	libudev-devel \
+	ncurses-devel \
+	numactl-devel \
+	openldap-devel \
+	openssl-devel \
+	perl \
+	perl-JSON rpcgen \
+	rpm-build \
+	time \
+	annobin-annocheck \
+	annobin-plugin-gcc \
+	binutils  \
+	dwz \
+	gcc \
+	gcc-c++ \
+	wget \
+	zlib-devel
+
+# temporarily remove the arch gcc-toolset plugindir patching
+
+echo "########################################################"
+echo "#           os preparation complete                    #"
+echo "########################################################"

--- a/config/ossetup/ol10__9.4.0.sh
+++ b/config/ossetup/ol10__9.4.0.sh
@@ -3,6 +3,11 @@
 ############################################################################
 #                                                                          #
 # OS Setup for OL10 for 9.4.0                                              #
+# - see: https://bugs.mysql.com/bug.php?id=118796 for initial issues       #
+#   building 9.4.0 on OL10.                                                #
+# - updates in 9.5.0 should resolve these issues.                          #
+# - pending: using dnf buildddep mysql.spec to auto-install dependencies   #
+#   and avoid having to add things explicitly here.                        #
 #                                                                          #
 ############################################################################
 
@@ -33,6 +38,22 @@ fi
 echo "### Enabling extra repo: $extra_repo"
 yum config-manager --set-enabled $extra_repo
 
+# Install EPEL repo
+if rpm -q oraclelinux-release 2>&1 >/dev/null; then
+	echo "- setting up oracle-epel-release-el10 repo"
+	yum -y install oracle-epel-release-el10
+	yum config-manager --set-enabled ol10_u0_developer_EPEL
+elif rpm -q almalinux-release 2>&1 >/dev/null; then
+	echo "- setting up epel-release repo"
+	dnf install -y epel-release
+elif rpm -q rocky-release 2>&1 >/dev/null; then
+	echo "- setting up epel-release repo"
+	dnf install -y epel-release
+else
+	echo "- EPEL repo handling not supported on this OS yet. Please fix"
+	exit 1
+fi
+
 echo "### installing required rpms"
 yum install -y \
 	annobin-annocheck \
@@ -41,6 +62,7 @@ yum install -y \
 	binutils  \
 	bison \
 	cmake \
+	curl-devel \
 	cyrus-sasl-devel \
 	dwz \
 	gcc \
@@ -58,8 +80,10 @@ yum install -y \
 	numactl-devel \
 	openldap-devel \
 	openssl-devel \
+	patchelf \
 	perl \
-	perl-JSON rpcgen \
+	perl-JSON \
+	rpcgen \
 	rpm-build \
 	time \
 	wget \

--- a/images.conf
+++ b/images.conf
@@ -3,9 +3,11 @@
 #
 almalinux8    almalinux:8
 almalinux9    almalinux:9
+almalinux10   almalinux:10
 
 rocky8        rockylinux:8
 rocky9        rockylinux:9
+rocky10       rockylinux/rockylinux:10
 
 centos7       quay.io/centos/centos:7
 centos8       quay.io/centos/centos:stream8

--- a/start-docker-container.sh
+++ b/start-docker-container.sh
@@ -59,4 +59,4 @@ done
 shift $(($OPTIND - 1))
 
 echo "Starting mysql-rpm-builder using image: $image and parameters $*"
-docker run --rm -it --network=host --hostname=buildhost -v $PWD:/data $image $*
+docker run --rm -it --network=host --hostname=buildhost -v $PWD:/data -w /data $image $*


### PR DESCRIPTION
Trying to update repo to work with OL10 and build against 8.4.6 and 9.4.0 I come up with an unexpected error.
Reported upstream as https://bugs.mysql.com/bug.php?id=118796.

Code appears to correctly:
- create the container
- setup the build environment
- pull down the required src rpm
- build

However, this currently fails for no apparent reason.  It seems like the build process from the src rpm and given rpm build environment do not match.

This can be tested in 2 ways:

# first way
- checkout the repo
- checkout this branch (`sjmudd/ol10-9.4.0-failed-build`)
- ensure your user has uid:gid 1000:1000 (may not be entirely necessary)
- run `./build_one ol10 9.4.0`
- wait for build failure

# second method (longer)

```
# as HOST user, start container

git clone https://github.com/sjmudd/mysql-rpm-builder.git
cd mysql-rpm-builder
git checkout sjmudd/ol10-9.4.0-failed-build
./start-docker-container.sh -i oraclelinux:10 bash   # jump into oraclelinux 10 container with repo located at /data

### as root container user:

/data/config/ossetup/ol10__9.4.0.sh         # update container content for building rpms
/data/config/ossetup/create_rpmbuild_user   # setup non-root rpmbuild user
su - rpmbuild                               # change to rpmbuild user

### as rpmbuild container user:

rpm -ivh  https://dev.mysql.com/get/Downloads/MySQL-9.0/mysql-community-9.4.0-1.el10.src.rpm   # install src rpm from which binary rpms can be built.
cd rpmbuild/SPECS/
rpmbuild -ba mysql.spec 2>&1 | tee -a build.log                                                # build binary rpms
```